### PR TITLE
Fix - error: {"embeds": ["0"]}

### DIFF
--- a/src/DiscordHandler.php
+++ b/src/DiscordHandler.php
@@ -102,14 +102,14 @@ class DiscordHandler extends AbstractProcessingHandler
 
 			$fields[] = [
 				'name' => $key,
-				'value' => $value,
+				'value' => \mb_substr($value, 0, 1024),
 				'inline' => true,
 			];
 		}
 
 		return [
 			[
-				'title' => $record['message'],
+				'title' => \mb_substr($record['message'], 0, 256),
 				'timestamp' => $record['datetime']->format(\DateTime::ATOM),
 				'fields' => $fields,
 				'footer' => [


### PR DESCRIPTION
Discord webhook fail if title and value are greater than 256 and 1024 :
https://stackoverflow.com/questions/53935198/in-my-discord-webhook-i-am-getting-the-error-embeds-0